### PR TITLE
Add some generic keyfobs I have

### DIFF
--- a/RFLink/Plugins/Plugin_001.c
+++ b/RFLink/Plugins/Plugin_001.c
@@ -535,6 +535,37 @@ boolean Plugin_001(byte function, char *string)
    }
    #endif
 
+   #ifdef PLUGIN_065
+   // ==========================================================================
+   // Beginning of Signal translation for generic 24-bit keyfobs with length of
+   // the bit is 640us (two pulses per bit + one closing)
+   // ==========================================================================
+   if (RawSignal.Number == RAW_BUFFER_SIZE - 1)
+   {
+      int start = 0; 
+      for (start = 52; start > 0; start--) {
+         if (RawSignal.Pulses[start] > PULSE4000) {
+            start++; //skip the first long delay
+            int end = start + 48 + 1; //48 is actual data
+            if (RawSignal.Pulses[end] < PULSE4000) break; // exit if no second delay
+            for (int i = start; i < end; i += 2) { //validate pulse periods
+               if (RawSignal.Pulses[i] + RawSignal.Pulses[i] > 700) {
+                  goto exit_065;
+               }
+            }
+            for (int i = 0; i < 48; i++) {
+               RawSignal.Pulses[1 + i] = RawSignal.Pulses[start + i]; // reorder pulse array
+            }
+            RawSignal.Number = 48;
+            RawSignal.Pulses[0] = 65;
+            return false;
+         }
+      }
+      exit_065:;
+   }
+   // ==========================================================================
+   #endif
+
    #if (defined(PLUGIN_046) ||  defined(PLUGIN_064))
    // ==========================================================================
    // Beginning of Signal translation for Atlantic/Visonic alarm detectors
@@ -777,6 +808,7 @@ Plugin  Pulselength
 048     126-290
 060     26
 061     50
+065     49
 070     36
 071     66
 072     26

--- a/RFLink/Plugins/Plugin_065.c
+++ b/RFLink/Plugins/Plugin_065.c
@@ -1,0 +1,107 @@
+//#######################################################################################################
+//##                    This Plugin is only for use with the RFLink software package                   ##
+//##                                     Plugin-062: Chuango AlarmSensors                              ##
+//#######################################################################################################
+/*********************************************************************************************\
+ * This protocol provides support for Chuango Alarm sensors (Motion detectors and door/window contacts)
+ * Note that these modules are reported as X10 switches to the Home Automation software so that they work correctly 
+ *
+ * Author  (present)  : StormTeam 2018..2020 - Marc RIVES (aka Couin3)
+ * Support (present)  : https://github.com/couin3/RFLink 
+ * Author  (original) : StuntTeam 2015..2016
+ * Support (original) : http://sourceforge.net/projects/rflink/
+ * License            : This code is free for use in any open source project when this header is included.
+ *                      Usage of any parts of this code in a commercial application is prohibited!
+ *********************************************************************************************
+ * Technical data:
+ * Devices send 48 pulses, 24 bits. However RFLink 
+ *
+ * Sample:
+ * 20;XX;DEBUG;Pulses=49;Pulses(uSec)=192,448,160,480,480,160,480,160,448,192,128,512,128,544,96,544,448,192,128,512,160,512,480,160,128,512,480,160,480,192,128,512,480,160,480,160,128,512,448,192,128,512,128,512,128,512,448,192,96;
+ * 20;XX;DEBUG;Pulses=49;Pulses(uSec)=160,480,192,448,480,160,480,160,448,192,128,512,128,512,128,512,448,192,96,544,96,512,480,160,128,512,480,160,480,160,128,512,480,160,480,160,128,512,480,160,128,512,128,512,128,512,480,160,96;
+ * 00111000 10010110 11010001   = 0x3896d1
+ \*********************************************************************************************/
+#define GARAGE640_PLUGIN_ID 065
+#define PLUGIN_DESC_065 "GARAGE640"
+
+#define GARAGE640_PULSECOUNT 48
+
+#define GARAGE640_PULSEMID (320 / RAWSIGNAL_SAMPLE_RATE)
+#define GARAGE640_PULSEMAX (540 / RAWSIGNAL_SAMPLE_RATE)
+#define GARAGE640_PULSEMIN (60 / RAWSIGNAL_SAMPLE_RATE)
+
+#ifdef PLUGIN_065
+#include "../4_Display.h"
+
+boolean Plugin_065(byte function, char *string) {
+   if (RawSignal.Number < GARAGE640_PULSECOUNT+10)
+      return false;
+
+   int start = 2; 
+   for (; start < GARAGE640_PULSECOUNT + 10; start++) {
+      if (RawSignal.Pulses[start] > PULSE4000) {
+         //first long delay found
+         start++;
+         break;
+      }
+   }
+   int end = start + GARAGE640_PULSECOUNT;
+   if (RawSignal.Pulses[start - 1] < PULSE4000 || RawSignal.Pulses[end + 1] < PULSE4000) {
+      return false;
+   }
+
+   unsigned long bitstream = 0L;
+   //==================================================================================
+   // Get all 24 bits
+   //==================================================================================
+   for (byte x = start; x < end; x += 2)
+   {
+      if (RawSignal.Pulses[x] > GARAGE640_PULSEMID)
+      {
+         if (RawSignal.Pulses[x] > GARAGE640_PULSEMAX)
+            return false; // pulse too long
+         if (RawSignal.Pulses[x + 1] > GARAGE640_PULSEMID)
+            return false; // invalid pulse sequence 10/01
+         bitstream = (bitstream << 1) | 0x1;
+      }
+      else
+      {
+         if (RawSignal.Pulses[x] < GARAGE640_PULSEMIN)
+            return false; // pulse too short
+         if (RawSignal.Pulses[x + 1] < GARAGE640_PULSEMID)
+            return false; // invalid pulse sequence 10/01
+         bitstream = bitstream << 1;
+      }
+   }
+   //==================================================================================
+   // Prevent repeating signals from showing up
+   //==================================================================================
+   if ((SignalHash != SignalHashPrevious) || ((RepeatingTimer + 200) < millis()) || (SignalCRC != bitstream))
+   {
+      // not seen the RF packet recently
+      if (bitstream == 0)
+         return false;
+
+      SignalCRC = bitstream;
+   }
+   else
+   {
+      // already seen the RF packet recently
+      return true;
+   }
+   //==================================================================================
+   // Validity checks
+   //==================================================================================
+   // Output
+   // ----------------------------------
+   display_Header();
+   display_Name(PSTR("GARAGE640"));
+   display_IDn((bitstream & 0xFFFFFF), 6); // "%S%06lx"
+   display_Footer();
+
+   //==================================================================================
+   RawSignal.Repeats = true; // suppress repeats of the same RF packet
+   RawSignal.Number = 0;
+   return true;
+}
+#endif // Plugin_065

--- a/RFLink/Plugins/Plugin_065.c
+++ b/RFLink/Plugins/Plugin_065.c
@@ -1,10 +1,9 @@
 //#######################################################################################################
 //##                    This Plugin is only for use with the RFLink software package                   ##
-//##                                     Plugin-062: Chuango AlarmSensors                              ##
+//##                                     Plugin-065: 640us-based keyfobs                               ##
 //#######################################################################################################
 /*********************************************************************************************\
- * This protocol provides support for Chuango Alarm sensors (Motion detectors and door/window contacts)
- * Note that these modules are reported as X10 switches to the Home Automation software so that they work correctly 
+ * This protocol provides support for basic keyfobs, used in garage openers
  *
  * Author  (present)  : StormTeam 2018..2020 - Marc RIVES (aka Couin3)
  * Support (present)  : https://github.com/couin3/RFLink 
@@ -14,7 +13,7 @@
  *                      Usage of any parts of this code in a commercial application is prohibited!
  *********************************************************************************************
  * Technical data:
- * Devices send 48 pulses, 24 bits. However RFLink 
+ * Devices send 48 pulses, 24 bits total.
  *
  * Sample:
  * 20;XX;DEBUG;Pulses=49;Pulses(uSec)=192,448,160,480,480,160,480,160,448,192,128,512,128,544,96,544,448,192,128,512,160,512,480,160,128,512,480,160,480,192,128,512,480,160,480,160,128,512,448,192,128,512,128,512,128,512,448,192,96;
@@ -34,27 +33,15 @@
 #include "../4_Display.h"
 
 boolean Plugin_065(byte function, char *string) {
-   if (RawSignal.Number < GARAGE640_PULSECOUNT+10)
+   if (RawSignal.Number != GARAGE640_PULSECOUNT || RawSignal.Pulses[0] != 65)
       return false;
 
-   int start = 2; 
-   for (; start < GARAGE640_PULSECOUNT + 10; start++) {
-      if (RawSignal.Pulses[start] > PULSE4000) {
-         //first long delay found
-         start++;
-         break;
-      }
-   }
-   int end = start + GARAGE640_PULSECOUNT;
-   if (RawSignal.Pulses[start - 1] < PULSE4000 || RawSignal.Pulses[end + 1] < PULSE4000) {
-      return false;
-   }
 
    unsigned long bitstream = 0L;
    //==================================================================================
    // Get all 24 bits
    //==================================================================================
-   for (byte x = start; x < end; x += 2)
+   for (byte x = 1; x < GARAGE640_PULSECOUNT; x += 2)
    {
       if (RawSignal.Pulses[x] > GARAGE640_PULSEMID)
       {

--- a/RFLink/Plugins/_Plugin_Config_01.h
+++ b/RFLink/Plugins/_Plugin_Config_01.h
@@ -61,6 +61,7 @@
 #define PLUGIN_062 // Chuango Alarm Devices
 #define PLUGIN_063 // Oregon PIR/ALARM/LIGHT
 #define PLUGIN_064 // Atlantic (and Visonic)
+#define PLUGIN_065 // custom garage doors
 // -------------------
 // Doorbells
 // -------------------


### PR DESCRIPTION
Hi. I've added receive support for some keyfobs laying around, so I can now script it to something useful on the server. 

I am kinda confused by the code: 
* on one hand it would be cool to have everything related in a single file
* on the other existing large messages are split in two parts: plugin 001, where initial packet extraction happens, and actual plugin XXX where it is decoded

so I left both commits here and you can choose if it's correct to accept both or just the first one