### PR TITLE
Plugin4 uses the strtok function which modifies its first argument, killing later plugins

### DIFF
--- a/RFLink/4_Display.cpp
+++ b/RFLink/4_Display.cpp
@@ -353,13 +353,15 @@ void display_CHAN(byte channel)
 // get label shared func //
 // --------------------- //
 
+char retrieveBuffer[INPUT_COMMAND_SIZE];
 char *ptr;
 const char c_delim[2] = ";";
 char c_label[12];
 
-void retrieve_Init(char* inputBuffer)
+void retrieve_Init()
 {
-  ptr = strtok(inputBuffer, c_delim);
+  memcpy(retrieveBuffer, InputBuffer_Serial, INPUT_COMMAND_SIZE);
+  ptr = strtok(retrieveBuffer, c_delim);
 }
 
 boolean retrieve_Name(const char *c_Name)

--- a/RFLink/4_Display.cpp
+++ b/RFLink/4_Display.cpp
@@ -357,9 +357,9 @@ char *ptr;
 const char c_delim[2] = ";";
 char c_label[12];
 
-void retrieve_Init()
+void retrieve_Init(char* inputBuffer)
 {
-  ptr = strtok(InputBuffer_Serial, c_delim);
+  ptr = strtok(inputBuffer, c_delim);
 }
 
 boolean retrieve_Name(const char *c_Name)

--- a/RFLink/4_Display.h
+++ b/RFLink/4_Display.h
@@ -83,7 +83,7 @@ void display_METER(unsigned int);
 void display_VOLT(unsigned int);
 void display_RGBW(unsigned int);
 
-void retrieve_Init();
+void retrieve_Init(char* inputBuffer);  // inputBuffer WILL be modified
 boolean retrieve_Name(const char *);
 boolean retrieve_ID(unsigned long &);
 boolean retrieve_Switch(byte &);

--- a/RFLink/4_Display.h
+++ b/RFLink/4_Display.h
@@ -83,7 +83,7 @@ void display_METER(unsigned int);
 void display_VOLT(unsigned int);
 void display_RGBW(unsigned int);
 
-void retrieve_Init(char* inputBuffer);  // inputBuffer WILL be modified
+void retrieve_Init();
 boolean retrieve_Name(const char *);
 boolean retrieve_ID(unsigned long &);
 boolean retrieve_Switch(byte &);

--- a/RFLink/Plugins/Plugin_004.c
+++ b/RFLink/Plugins/Plugin_004.c
@@ -172,9 +172,7 @@ boolean PluginTX_004(byte function, char *string)
    byte Cmd_bitstream = 0;          // 2 bits Command
    byte Cmd_dimmer = 0;             // 4 bits Alt Command
 
-   char inputBuffer[INPUT_COMMAND_SIZE];
-   memcpy(inputBuffer, InputBuffer_Serial, INPUT_COMMAND_SIZE);
-   retrieve_Init(inputBuffer);
+   retrieve_Init();
 
    if (!retrieve_Name("10"))
       return false;

--- a/RFLink/Plugins/Plugin_004.c
+++ b/RFLink/Plugins/Plugin_004.c
@@ -172,7 +172,10 @@ boolean PluginTX_004(byte function, char *string)
    byte Cmd_bitstream = 0;          // 2 bits Command
    byte Cmd_dimmer = 0;             // 4 bits Alt Command
 
-   retrieve_Init();
+   char inputBuffer[INPUT_COMMAND_SIZE];
+   memcpy(inputBuffer, InputBuffer_Serial, INPUT_COMMAND_SIZE);
+   retrieve_Init(inputBuffer);
+
    if (!retrieve_Name("10"))
       return false;
    if (!retrieve_Name("Newkaku"))


### PR DESCRIPTION
We must thus make sure InputBuffer_Serial is not modified for other plugins to be able to work properly