### PR TITLE
Fix FA21RF smoke detector detection

### DIFF
--- a/RFLink/Plugins/Plugin_080.c
+++ b/RFLink/Plugins/Plugin_080.c
@@ -37,7 +37,7 @@
 #define FA20_PLUGIN_ID 080
 #define PLUGIN_DESC_080 "FA20RF"
 
-#define FA20_PULSECOUNT 52
+#define FA20_PULSECOUNT 50
 
 #define FA20_MIDHI 1000 / RAWSIGNAL_SAMPLE_RATE
 #define FA20_PULSEMIN 1000 / RAWSIGNAL_SAMPLE_RATE
@@ -57,7 +57,7 @@ boolean Plugin_080(byte function, char *string)
    //==================================================================================
    // Get all 24 bits
    //==================================================================================
-   for (byte x = 4; x < FA20_PULSECOUNT; x += 2)
+   for (byte x = 2; x < FA20_PULSECOUNT; x += 2)
    {
       if (RawSignal.Pulses[x - 1] > FA20_MIDHI)
          return false; // every preceding pulse must be below 1000!


### PR DESCRIPTION
I've got a FA21RF smoke detector that was not properly detected by my ESP but works with the original RFLink. When comparing the raw signals, the original RFLink receives two more bytes at the beginning, but throws them away. The ESP RFLink does not receive these two bytes, unless `SIGNAL_END_TIMEOUT_US` is increased to about 10000. Since I expect side effects from that, I changed the FA21RF signal detection.

Transmission is untested as the transmitter behaves a bit weird on my Wemos D1 Mini. I'll investigate this later.